### PR TITLE
Fix for URLs concatenating without the "/" at the end

### DIFF
--- a/nosqlmap.py
+++ b/nosqlmap.py
@@ -247,6 +247,9 @@ def options():
 
         elif select == "3":
             uri = raw_input("Enter URI Path (Press enter for no URI): ")
+            #Ensuring the URI path always starts with / and causes less errors
+            if uri[0] != "/":
+                uri = "/" + uri
             print "\nURI Path set to " + uri + "\n"
             optionSet[2] = True
 


### PR DESCRIPTION
Added in a patch for URLs not working when they do not start with a /