### PR TITLE
Fixed bugs in choosing payload length and format

### DIFF
--- a/nsmweb.py
+++ b/nsmweb.py
@@ -125,7 +125,8 @@ def getApps(webPort,victim,uri,https,verb,requestHeaders, args = None):
         else:
             injectSize = int(args.injectSize)
             format = args.injectFormat
-            
+
+        injectSize = int(injectSize)
         injectString = build_random_string(format, injectSize)
 
         print "Using " + injectString + " for injection testing.\n"
@@ -869,13 +870,13 @@ def randInjString(size):
     print "2-Letters only"
     print "3-Numbers only"
     print "4-Email address"
-    format = True
 
-    while format:
+    while True:
         format = raw_input("Select an option: ")
         if format not in ["1", "2", "3", "4"]:
-            format = True
             print "Invalid selection."
+        else:
+            break
     return format
 
 def build_random_string(format, size):


### PR DESCRIPTION
Fixed the following bug and other relevant error in nosql web attack.

```
  _     ___  ___  _    __  __           
| \| |___/ __|/ _ \| |  |  \/  |__ _ _ __ 
| .` / _ \__ \ (_) | |__| |\/| / _` | '_ \
|_|\_\___/___/\__\_\____|_|  |_\__,_| .__/
 v0.7 codingo@protonmail.com        |_|   

1-Set options
2-NoSQL DB Access Attacks
3-NoSQL Web App attacks
4-Scan for Anonymous MongoDB Access
5-Change Platform (Current: MongoDB)
x-Exit
Select an option: 3
Web App Attacks (GET)
===============
Checking to see if site at http://juice-shop.herokuapp.com:80/#/track-result?id=juice-shop.herokuapp.com/#/track-result … is up...
App is up!
Baseline test-Enter random string size: 5
What format should the random string take?
1-Alphanumeric
2-Letters only
3-Numbers only
4-Email address
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option: 1
Select an option:

```