### PR TITLE
nosqlmap.py: invalid header

### DIFF
--- a/nosqlmap.py
+++ b/nosqlmap.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 # NoSQLMap Copyright 2012-2017 NoSQLMap Development team
 # See the file 'doc/COPYING' for copying permission
 


### PR DESCRIPTION
"coding" should come in the second line, see:
https://www.python.org/dev/peps/pep-0263/