### PR TITLE
Added exception.py to setuptools script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 			name = "NoSQLMap",
 			version = "0.7",
 			packages = find_packages(),
-			scripts = ['nosqlmap.py', 'nsmmongo.py', 'nsmcouch.py','nsmscan.py','nsmweb.py'],
+			scripts = ['nosqlmap.py', 'nsmmongo.py', 'nsmcouch.py', 'nsmscan.py', 'nsmweb.py', 'exception.py'],
 			
 			entry_points = {
 				"console_scripts": [


### PR DESCRIPTION
After [Added base exception class NoSQLMapException inside exception.py. #99](https://github.com/codingo/NoSQLMap/pull/99), using NoSQLMap when installed with `python setup.py install` fails with the following log:

```
root@kali:~/NoSQLMap# nosqlmap.py --attack 2 --victim target-site.com --webPort 80 --uri /login --httpMethod POST --postData email,user@target-site.com,password,password --injectedParameter 1 --injectSize 0 --injectFormat 2 --savePath output.log
Traceback (most recent call last):
  File "/usr/local/bin/nosqlmap.py", line 4, in <module>
    __import__('pkg_resources').run_script('NoSQLMap==0.7', 'nosqlmap.py')
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/NoSQLMap-0.7-py2.7.egg/EGG-INFO/scripts/nosqlmap.py", line 6, in <module>
    
ImportError: No module named exception
```
Without installing with `python setup.py install`, this command completes successfully. After some debugging it looks like the `exception.py` is not installed with setuptools - adding the filename to the scripts list in `setup.py` fixes the issue.