### PR TITLE
Change Dockerfile to install and build a stable version of Certifi

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,9 @@ WORKDIR /root/NoSqlMap
 
 RUN python setup.py install
 
+RUN pip2 uninstall certifi -y
+RUN pip2 install certifi==2018.10.15
+
 COPY entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 


### PR DESCRIPTION
Changes in `Dockerfile` in order to install and build a stable version of Certifi