### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /root/NoSqlMap
 
 RUN python setup.py install
 
+RUN python -m pip install requests 'certifi<=2020.4.5.1'
+
 COPY entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 


### PR DESCRIPTION
Fixing the dependency error. Certifi's last python 2.7 release is 2020.04.5, otherwise the docker run command will raise a error.